### PR TITLE
Add DescriptionForTagHelper

### DIFF
--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml
@@ -315,14 +315,46 @@
 <h4>Example</h4>
 <div class="panel panel-default">
     <div class="panel-body">
-        <partial name="_Even" asp-if="(DateTime.UtcNow.Minute % 2) == 0" />
-        <partial name="_Odd" asp-if="(DateTime.UtcNow.Minute % 2) != 0" />
+        <partial name="_Even" asp-if="(DateTime.UtcNow.Minute % 2) == 0"/>
+        <partial name="_Odd" asp-if="(DateTime.UtcNow.Minute % 2) != 0"/>
     </div>
 </div>
 <h4>Source</h4>
 <figure>
     <pre>&lt;<strong>partial name="_Even" asp-if="(DateTime.UtcNow.Minute % 2) == 0"</strong> /&gt;
 &lt;<strong>partial name="_Odd" asp-if="(DateTime.UtcNow.Minute % 2) != 0"</strong> /&gt;</pre>
+</figure>
+
+<h3>Description For Tag Helper</h3>
+<p>
+    Use <code>&lt;<em>any-element</em> asp-description-for="..."&gt;</code> to display the content of a Description
+    from the
+    <code>
+        <em>DisplayAttribute</em>
+    </code> instance decorating a
+    <code>
+        <em>Model</em>
+    </code> property.
+    Works on any <strong>empty HTML element</strong>.
+</p>
+<h4>Example</h4>
+<div class="panel panel-default">
+    <div class="panel-body">
+        The Customer description is: <span asp-description-for="Customer"></span>
+    </div>
+</div>
+<h4>Source</h4>
+<h5>Razor Syntax</h5>
+<figure>
+    <pre>The Customer description is: <strong>&lt;span asp-description-for="Customer"&gt;&lt;span&gt;</strong></pre>
+</figure>
+<h5>C# Model</h5>
+<figure>    
+    <pre><code>
+[BindProperty, 
+ Display(Name="Customer", Description = "The Customer Name")]
+public Customer Customer { get; set; }
+    </code></pre>
 </figure>
 
 @section Scripts {

--- a/samples/TagHelperPack.Sample/Pages/Index.cshtml.cs
+++ b/samples/TagHelperPack.Sample/Pages/Index.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TagHelperPack.Sample.Models;
@@ -8,7 +9,8 @@ namespace TagHelperPack.Sample.Pages
 {
     public class IndexModel : PageModel
     {
-        [BindProperty]
+        [BindProperty, 
+         Display(Name="Customer", Description = "The Customer Name")]
         public Customer Customer { get; set; }
 
         public IReadOnlyList<string> Countries { get; } = new List<string> { "DE", "FR", "US" };

--- a/samples/TagHelperPack.Sample/TagHelperPack.Sample.csproj
+++ b/samples/TagHelperPack.Sample/TagHelperPack.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Targeting minimum supported versions here despite package targeting lower in some cases -->
-    <TargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>TagHelperPack.Sample</RootNamespace>
   </PropertyGroup>
 
@@ -16,6 +16,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">

--- a/src/TagHelperPack/DescriptionForTagHelper.cs
+++ b/src/TagHelperPack/DescriptionForTagHelper.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TagHelperPack;
+
+[HtmlTargetElement("*", Attributes = ForAttributeName)]
+public sealed class DescriptionForTagHelper : TagHelper
+{
+    private const string ForAttributeName = "asp-description-for";
+
+    [HtmlAttributeName(ForAttributeName)] 
+    public ModelExpression For { get; set; } = default!;
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (output == null)
+        {
+            throw new ArgumentNullException(nameof(output));
+        }
+
+        // will depend on model metadata from asp.net core
+        // this is very hard to unit test
+        var description = For.Metadata.Description;
+        if (description != null)
+        {
+            // Do not update the content if another tag helper targeting this element has already done so.
+            if (!output.IsContentModified)
+            {
+                var childContent = await output.GetChildContentAsync();
+                if (childContent.IsEmptyOrWhiteSpace)
+                {
+                    output.Content.SetHtmlContent(description);
+                }
+                else
+                {
+                    output.Content.SetHtmlContent(childContent);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add DescriptionForTagHelper, which will read the `Description` property from a `DisplayAttribute`. Includes a sample on the Sample project.